### PR TITLE
Possibility to prefer "related" links over resource linkage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- New methods to prefer fetching of related resources via `related` links instead of resource linkage when both a `data` and `links` member are present in a relationship
+
 ## [v0.0.3](https://github.com/muellerbbm-vas/grivet/compare/v0.0.2...v0.0.3) - 2019-02-12
 
 ### Fixed


### PR DESCRIPTION
Adds two new methods:

```typescript
Relationship.resourceFromRelatedLink()
Relationship.resourcesFromRelatedLink()
```

Helps with #27 by giving the user the option to use `related` links when they know that resource linkage will not work (e.g. because the resources are not included).

The new methods will fall back to the usual `resource()` or `resources()` methods if no `related` link is found or the link does not work.