### PR TITLE
fix: allow unknown members in document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Fixed
+
+- Unknown members in documents are no longer considered errors and are now ignored as per the standard
+
 ## [v0.0.6](https://github.com/muellerbbm-vas/grivet/compare/v0.0.5...v0.0.6) - 2019-10-23
 
 ### Fixed

--- a/src/jsonapiSpec.ts
+++ b/src/jsonapiSpec.ts
@@ -16,10 +16,7 @@ export namespace Spec {
    * @throws [[SchemaError]]
    */
   export function checkDocumentSchema(doc: JsonApiDocument) {
-    SchemaChecker.fromData(doc, 'Document')
-      .singleObject()
-      .atLeastOneOf(['data', 'errors', 'meta'])
-      .allowedMembers(['data', 'errors', 'meta', 'jsonapi', 'links', 'included']);
+    SchemaChecker.fromData(doc, 'Document').singleObject().atLeastOneOf(['data', 'errors', 'meta']);
     if ('data' in doc) {
       if (Array.isArray(doc['data'])) {
         for (const r of doc['data'] as object[]) {
@@ -39,10 +36,7 @@ export namespace Spec {
     if (res === null) {
       return;
     }
-    SchemaChecker.fromData(res, 'Resource object')
-      .singleObject()
-      .has(['id', 'type'])
-      .allowedMembers(['id', 'type', 'attributes', 'relationships', 'links', 'meta']);
+    SchemaChecker.fromData(res, 'Resource object').singleObject().has(['id', 'type']);
   }
 
   /**
@@ -50,9 +44,7 @@ export namespace Spec {
    * @throws [[SchemaError]]
    */
   export function checkRelationshipObjectSchema(rel: object) {
-    SchemaChecker.fromData(rel, 'Relationship object')
-      .singleObject()
-      .atLeastOneOf(['links', 'data', 'meta']);
+    SchemaChecker.fromData(rel, 'Relationship object').singleObject().atLeastOneOf(['links', 'data', 'meta']);
   }
 
   /**

--- a/test/tests.spec.ts
+++ b/test/tests.spec.ts
@@ -862,8 +862,12 @@ describe('Runtime SchemaErrors', () => {
   const malformedDocument = {
     dat: {
       id: '1',
-      type: 't'
-    }
+      type: 't',
+    },
+  };
+  const documentWithExtraUnknownMember = {
+    data: { id: '1', type: 't' },
+    bla: 'bla',
   };
   const malformedMainResource = {
     data: {
@@ -873,13 +877,20 @@ describe('Runtime SchemaErrors', () => {
 
   it('are thrown for malformed documents', () => {
     expect(() => {
-      const doc = new JsonApi.Document((malformedDocument as unknown) as Spec.JsonApiDocument, new TestContext({}));
+      const doc = new JsonApi.Document(malformedDocument as unknown as Spec.JsonApiDocument, new TestContext({}));
     }).toThrow(/must contain at least one of/);
   });
   it('are thrown for malformed main resources', () => {
     expect(() => {
       const doc = new JsonApi.Document(malformedMainResource as Spec.JsonApiDocument, new TestContext({}));
     }).toThrow(/must contain at least the following/);
+  });
+  it('are not thrown for documents that contain unknown members', () => {
+    const doc = new JsonApi.Document(
+      documentWithExtraUnknownMember as unknown as Spec.JsonApiDocument,
+      new TestContext({})
+    );
+    expect(doc).toBeDefined();
   });
 });
 


### PR DESCRIPTION
According to the JSON:API standard, unknown members must be
allowed and ignored (https://jsonapi.org/format/#document-structure)